### PR TITLE
bashrc: temp - fix format

### DIFF
--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -206,13 +206,18 @@ function top() {
   fi
 }
 
-# temperature
 function temp() {
-  echo "Disks"
+  printf "dev\t\ttype\ttemp\tserial\t\t\t\t\tmodel\n"
   for disk in /dev/sd[a-z] /dev/nvme[0-9]; do
-    [[ -c "$disk" ]] \
+    [[ -c "$disk" || -b "$disk" ]] \
       && sudo smartctl --all --json "$disk" \
-        | jq -r '"\(.device.info_name) \(.temperature.current)C \(.model_name) \(.serial_number)"'
+        | jq -r '
+          .device.name + "\t" +
+          .device.type + "\t" +
+          (.temperature.current | tostring) + "C\t" +
+          .serial_number + "\t\t\t" +
+          .model_name
+          '
   done
 }
 


### PR DESCRIPTION
# Changes

| File    | Change Description |
| ------- | ------------------ |
| bashrc  | fix temp format; fix sata disks detection |


nvme disks are not block devices( by....system ):
```
crw------- 1 root root 241, 0 дек  6 07:38 /dev/nvme0
```

but sata are block
```
brw-rw---- 1 root disk 8, 0 Dec  6 11:48 /dev/sda
```
