### PR TITLE
feat(workstation): consolidate workstation automation

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -24,6 +24,9 @@ automation under `.github/`.
   `.github/instructions/*.instructions.md`.
 - Keep documentation-specific Copilot rules in
   `.github/instructions/documentation.instructions.md`.
+- Keep AI instructions clear that the former `ans-workstation` layer is now
+  opt-in inside this repository, default `go-task` remains sudo-free, and
+  personal workstation settings are not a generic hardening benchmark.
 - Keep Neovim keymap review rules aligned with
   `docs/nvim-keymaps.md`, `dotfiles/.config/nvim/lua/config/keymaps_spec.lua`,
   and `Taskfile.yml`.

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -16,6 +16,10 @@ automation under `.github/`.
 - Keep workflow permissions minimal and explicit.
 - Keep workflow concurrency explicit for long-running or PR-triggered jobs.
 - Keep `.github/labeler.yml` aligned with the current repository structure.
+- Keep path labels declared in `.github/labeler.yml` present in GitHub, and
+  keep the changed-files label limit high enough for broad maintenance PRs.
+- Keep `docs/github-labels.md` aligned with labeler rules and issue-template
+  labels.
 - Keep issue and PR templates aligned with supported workflows and validation
   commands.
 - Keep GitHub Copilot custom instructions concise, review-focused, and aligned

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,8 @@
 # Repository Review Rules
 
 Review this personal Arch Linux dotfiles repo for reliability, security,
-idempotence, and low maintenance. The former `ans-workstation` layer now lives
-here only as opt-in system automation.
+idempotence, and low maintenance. Former `ans-workstation` automation is
+opt-in here.
 
 ## Critical Contracts
 
@@ -44,10 +44,9 @@ here only as opt-in system automation.
 
 - Docs and nearest `AGENTS.md` files must change with new commands, roles,
   validation paths, automation, or runtime behavior.
-- For Neovim changes, enforce the structured lazy.nvim layout, deterministic
-  `lazy-lock.json`, centralized `lua/config/languages.lua` tool lists,
-  `NVIM_USE_MASON` opt-in behavior, explicit Tree-sitter parser installs, and
-  first-buffer detection in `lua/config/filetypes.lua`.
+- For Neovim changes, enforce structured lazy.nvim layout, deterministic
+  `lazy-lock.json`, centralized tool lists, `NVIM_USE_MASON` opt-in behavior,
+  explicit Tree-sitter installs, and first-buffer filetype detection.
 - For Neovim keymap changes, require updates to
   `lua/config/keymaps_spec.lua` and `docs/nvim-keymaps.md`. Keymap docs must
   state the active leader key plainly and pass `go-task docs:nvim-keymaps:check`.
@@ -58,7 +57,9 @@ here only as opt-in system automation.
 - Keep repository text, comments, task names, docs, and AI instructions in
   English.
 - Keep GitHub Actions least-privilege, deterministic, and Renovate-updateable.
-- Keep `.github/labeler.yml`, templates, Renovate, and AI instructions aligned.
+- Leave `pyproject.toml` dependency constraints unpinned unless requested;
+  `uv.lock` records resolved versions.
+- Keep labeler, templates, Renovate, and AI instructions aligned.
 - Keep Super-Linter separate from `go-task lint`.
 
 ## Suggested Validation
@@ -71,7 +72,7 @@ here only as opt-in system automation.
   `go-task test:nvim:profile`.
 - Neovim keymaps: `go-task docs:nvim-keymaps:check`.
 - System role: `go-task system:check`; use `go-task test:system` for task,
-  template, or handler behavior when Docker is available.
+  template, or handler changes when Docker is available.
 - Browser policies: `go-task browser-policies:check`.
 - CI or repo-wide lint behavior: `go-task superlinter` when Docker is
   available.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,7 +65,8 @@ here only as opt-in system automation.
 
 - Ansible, inventory, role, Taskfile, or playbook changes: `go-task lint`.
 - YAML-heavy changes: `go-task yamllint`.
-- Default dotfiles flow or mappings: `go-task`.
+- Default dotfiles flow or mappings: `go-task dotfiles:check`; use `go-task`
+  when the apply path must be exercised.
 - Neovim config: `go-task test:nvim`; for startup-sensitive changes also run
   `go-task test:nvim:profile`.
 - Neovim keymaps: `go-task docs:nvim-keymaps:check`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,17 +1,20 @@
 # Repository Review Rules
 
-Review this Arch Linux dotfiles and opt-in workstation automation repo for
-reliability, security, idempotence, and low maintenance.
+Review this personal Arch Linux dotfiles repo for reliability, security,
+idempotence, and low maintenance. The former `ans-workstation` layer now lives
+here only as opt-in system automation.
 
 ## Critical Contracts
 
 - Default `go-task` must remain user-level and sudo-free.
-- `playbook_install.yml` must keep `become: false` and must not include
-  `roles/system` or `roles/browser_policies`.
-- `playbook_install.yml` may include `roles/dotfiles` only.
+- `playbook_install.yml` keeps `become: false` and may include
+  `roles/dotfiles` only.
 - Privileged system and browser policy behavior must stay opt-in.
+- Docs must not imply privileged configuration is part of default `go-task`.
+- Security wording must not present personal workstation values as a generic
+  hardening benchmark.
 - Reject secrets, private keys, browser profiles, caches, generated test
-  workspaces, copied local configs, and machine-local runtime state.
+  workspaces, local configs, and machine-local runtime state.
 
 ## Ansible Review
 
@@ -21,18 +24,15 @@ reliability, security, idempotence, and low maintenance.
 - Role variables, registered facts, and non-trivial task vars use
   `dotfiles_`, `system_`, or `browser_policies_`.
 - Non-trivial loops set `loop_control.loop_var`; avoid generic `item`.
-- Validate role input variables in `tasks/validate.yml` when they form a real
-  contract.
-- Keep host vars split under `inventory/host_vars/this_host/`; do not recreate
-  a monolithic host vars file.
+- Validate role inputs in `tasks/validate.yml` when they form a contract.
+- Keep host vars split under `inventory/host_vars/this_host/`.
 - Prefer FQCN modules, idempotence, explicit ownership/modes, and handlers.
 - Flag shell/command unless it has clear idempotence through
   `changed_when`, `creates`, `removes`, or an equivalent guard.
-- Dotfiles mappings must use `name`, relative `payload`, and absolute `dest`;
-  the role computes `src` and creates destination parent directories.
-- System setting maps should use `system_journald_settings`,
-  `system_sshd_settings`, and `system_sysctl_settings`; preserve upstream
-  option casing inside those maps.
+- Dotfiles mappings use `name`, relative `payload`, and absolute `dest`.
+- System setting maps use `system_journald_settings`,
+  `system_sshd_settings`, and `system_sysctl_settings`; preserve upstream key
+  casing.
 - Prefer system drop-ins over editing upstream main config files where
   supported.
 - PAM limits must use `/etc/security/limits.d/`; kernel module options must use
@@ -42,19 +42,19 @@ reliability, security, idempotence, and low maintenance.
 
 ## Repository Review
 
-- Docs and nearest `AGENTS.md` files must change with new commands, playbooks,
-  roles, validation paths, automation, or runtime behavior.
+- Docs and nearest `AGENTS.md` files must change with new commands, roles,
+  validation paths, automation, or runtime behavior.
 - For Neovim changes, enforce the structured lazy.nvim layout, deterministic
-  `lazy-lock.json`, centralized `lua/config/languages.lua` tool lists, and
-  `NVIM_USE_MASON` opt-in behavior. Tree-sitter parser installation must stay
-  explicit and skip cleanly when required external tools are unavailable.
-  Filetype-lazy plugins must have first-buffer detection in
-  `lua/config/filetypes.lua`.
+  `lazy-lock.json`, centralized `lua/config/languages.lua` tool lists,
+  `NVIM_USE_MASON` opt-in behavior, explicit Tree-sitter parser installs, and
+  first-buffer detection in `lua/config/filetypes.lua`.
 - For Neovim keymap changes, require updates to
   `lua/config/keymaps_spec.lua` and `docs/nvim-keymaps.md`. Keymap docs must
   state the active leader key plainly and pass `go-task docs:nvim-keymaps:check`.
 - Check role READMEs, issue forms, and PR templates when their workflows,
   validation, safety rules, managed files, variables, or rollback change.
+- Keep architecture, adoption, security, and migration/history docs aligned
+  when system-layer behavior or consolidation wording changes.
 - Keep repository text, comments, task names, docs, and AI instructions in
   English.
 - Keep GitHub Actions least-privilege, deterministic, and Renovate-updateable.

--- a/.github/instructions/ansible.instructions.md
+++ b/.github/instructions/ansible.instructions.md
@@ -22,6 +22,8 @@ applyTo: "playbook_*.yml,inventory/**/*.yml,roles/**/*.yml,requirements.yml,ansi
 - Preserve the default dotfiles contract: `playbook_install.yml` stays local,
   user-level, `become: false`, and includes only `roles/dotfiles`.
 - Keep `roles/dotfiles` user-level and sudo-free.
+- Keep `roles/system` as the opt-in layer consolidated from the former
+  `ans-workstation` automation; do not route it through default `go-task`.
 - Dotfiles mapping entries must use `name`, relative `payload`, and absolute
   `dest`.
 - Keep system and browser policy automation opt-in through their dedicated

--- a/.github/instructions/ansible.instructions.md
+++ b/.github/instructions/ansible.instructions.md
@@ -22,6 +22,7 @@ applyTo: "playbook_*.yml,inventory/**/*.yml,roles/**/*.yml,requirements.yml,ansi
 - Preserve the default dotfiles contract: `playbook_install.yml` stays local,
   user-level, `become: false`, and includes only `roles/dotfiles`.
 - Keep `roles/dotfiles` user-level and sudo-free.
+- Use `go-task dotfiles:check` for user-level dotfiles dry-runs.
 - Keep `roles/system` as the opt-in layer consolidated from the former
   `ans-workstation` automation; do not route it through default `go-task`.
 - Dotfiles mapping entries must use `name`, relative `payload`, and absolute

--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -17,6 +17,12 @@ applyTo: "**/*.md,**/AGENTS.md,.github/copilot-instructions.md,.github/instructi
   `AGENTS.md`.
 - Preserve the default contract in docs: `go-task` applies user-level
   dotfiles only and must not require sudo.
+- Document the former `tenhishadow/ans-workstation` consolidation factually
+  where repository history or architecture is relevant.
+- Do not imply privileged system or browser policy configuration is part of
+  default `go-task`.
+- Do not present personal workstation security settings as a generic hardening
+  benchmark.
 - Keep generated manuals current. For Neovim keymaps, regenerate
   `docs/nvim-keymaps.md` with `go-task docs:nvim-keymaps` and verify it with
   `go-task docs:nvim-keymaps:check`.
@@ -24,5 +30,7 @@ applyTo: "**/*.md,**/AGENTS.md,.github/copilot-instructions.md,.github/instructi
   `dotfiles_*`, `system_*`, and `browser_policies_*`.
 - Document system role feature flags, managed paths, and drop-in/snippet paths
   when privileged runtime behavior changes.
+- Update architecture, adoption, security, and migration/history docs when
+  system-layer behavior or consolidation wording changes.
 - Mention `go-task verify` for broad documentation, automation, inventory, or
   role changes.

--- a/.github/instructions/github-automation.instructions.md
+++ b/.github/instructions/github-automation.instructions.md
@@ -23,6 +23,10 @@ applyTo: ".github/**/*.yml,.github/**/*.yaml,.github/**/*.md,renovate.json,Taskf
 - Keep `.github/labeler.yml` aligned with current repository paths, including
   AI instructions under `AGENTS.md`, `.github/copilot-instructions.md`, and
   `.github/instructions/`.
+- Keep labeler path labels present in GitHub and avoid a changed-file label
+  limit that makes broad maintenance PRs skip all labels.
+- Keep `docs/github-labels.md` aligned with labeler rules and issue-template
+  labels.
 - Keep issue forms and the PR template aligned with supported workflows and
   validation commands.
 - Keep Copilot instructions concise, review-focused, and non-duplicative:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -98,6 +98,11 @@ security:
           - "dotfiles/.ssh/**/*"
           - "inventory/host_vars/this_host/security.yml"
           - "roles/browser_policies/**/*"
+          - "roles/system/defaults/main.yml"
+          - "roles/system/tasks/sys-limits.yml"
+          - "roles/system/tasks/sys-sshd.yml"
+          - "roles/system/tasks/sys-sysctl.yml"
+          - "roles/system/templates/limits-dropin.conf.j2"
           - "roles/system/templates/sshd-dropin.conf.j2"
 
 shell:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,8 @@
 ---
-changed-files-labels-limit: 8
+# Broad maintenance PRs can legitimately touch docs, automation, roles,
+# dependencies, and AI instructions together. If this limit is exceeded,
+# actions/labeler skips all changed-file labels.
+changed-files-labels-limit: 20
 max-files-changed: 300
 
 ai-instructions:

--- a/.test/AGENTS.md
+++ b/.test/AGENTS.md
@@ -13,7 +13,11 @@ workspaces.
 - `.test/nvim/keymap_docs.lua`
 - `.test/nvim/mason_tools.lua`
 - `.test/nvim/*` language sample fixtures
+- `.test/vint_runner.py`
 - `.test/system/exec.sh`
+
+`.test/vint_runner.py` runs vim-vint with a minimal `pkg_resources`
+compatibility shim so the project environment does not need `setuptools`.
 
 `.test/system/exec.sh` is the Arch Linux container smoke and idempotency script
 used by `go-task test:system`.

--- a/.test/vint_runner.py
+++ b/.test/vint_runner.py
@@ -1,0 +1,29 @@
+"""Run vim-vint without requiring setuptools in the project environment."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import sys
+import types
+
+
+class DistributionNotFound(Exception):
+    """Compatibility exception used by vim-vint."""
+
+
+def _require(name: str) -> list[types.SimpleNamespace]:
+    try:
+        return [types.SimpleNamespace(version=importlib.metadata.version(name))]
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise DistributionNotFound(name) from exc
+
+
+pkg_resources = types.ModuleType("pkg_resources")
+setattr(pkg_resources, "DistributionNotFound", DistributionNotFound)
+setattr(pkg_resources, "require", _require)
+sys.modules["pkg_resources"] = pkg_resources
+
+
+if __name__ == "__main__":
+    getattr(importlib.import_module("vint"), "main")()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,8 +172,9 @@ Ansible, `uv`, and `go-task`.
 ## Validation Matrix
 
 - Always run `git diff --check` before finishing non-trivial changes.
-- Run `go-task` for user dotfiles, symlink mappings, cleanup, or default
-  install flow changes.
+- Run `go-task dotfiles:check` for user dotfiles, symlink mappings, cleanup,
+  or default install flow changes; run `go-task` when the apply path must be
+  exercised.
 - Run `go-task lint` for Ansible, inventory, role, Taskfile, or playbook
   changes.
 - Run `uv run yamllint .` or `go-task yamllint` for YAML-heavy changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,8 @@ Ansible, `uv`, and `go-task`.
   them.
 - Preserve CI and container guards for privileged system behavior.
 - Do not broaden cleanup/removal patterns without an explicit requirement.
+- Keep Python tool dependencies in `pyproject.toml` unpinned unless the user
+  explicitly asks for a constraint. Let `uv.lock` carry resolved versions.
 
 ## Ansible Naming Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Repository
 
-Arch Linux dotfiles and workstation automation repository managed with
+Personal Arch Linux dotfiles and workstation automation repository managed with
 Ansible, `uv`, and `go-task`.
 
 ## Architecture
@@ -13,10 +13,12 @@ Ansible, `uv`, and `go-task`.
 - `inventory/host_vars/this_host/` is the local source of truth for dotfiles
   mappings, cleanup, browser policy overrides, and system role values.
 - `roles/dotfiles/` contains the default user-level dotfiles workflow.
-- `roles/system/` contains opt-in Arch Linux workstation provisioning.
+- `roles/system/` contains opt-in Arch Linux workstation provisioning
+  consolidated from the former `tenhishadow/ans-workstation` repository.
 - `roles/browser_policies/` contains opt-in browser and VS Code policy
   management.
-- `docs/` contains generated operator manuals, including Neovim keymaps.
+- `docs/` contains architecture, adoption, security, migration, and generated
+  operator manuals.
 
 ## Instruction Scope
 
@@ -43,6 +45,10 @@ Ansible, `uv`, and `go-task`.
   `roles/system` or `roles/browser_policies` to `playbook_install.yml`.
 - Keep privileged and system-wide behavior behind explicit opt-in
   playbooks/tasks.
+- Preserve the documented execution boundary: default `go-task` must not be
+  described as applying privileged system or browser policy configuration.
+- Do not present personal workstation security values as a generic hardening
+  benchmark.
 - Prefer service drop-ins over editing upstream main config files where
   supported.
 - Keep changes deterministic, narrow, reviewable, and idempotent.
@@ -110,6 +116,10 @@ Ansible, `uv`, and `go-task`.
   user-level, local, sudo-free, and limited to `playbook_install.yml`.
 - Flag any privileged behavior that leaks into the default dotfiles playbook
   or bypasses the explicit system and browser policy playbooks.
+- Flag docs that imply privileged configuration is part of the default
+  `go-task`, omit the former `ans-workstation` consolidation where relevant,
+  or describe this personal workstation baseline as a generic hardening
+  benchmark.
 - Flag Ansible tasks that are not idempotent, omit FQCN modules, omit explicit
   modes for managed files, use unguarded shell/command calls, or duplicate
   values that belong in inventory/defaults/vars.
@@ -134,6 +144,8 @@ Ansible, `uv`, and `go-task`.
   change.
 - Update role README files when role variables, managed paths, task flow,
   validation, or rollback behavior changes.
+- Update architecture, adoption, security, and migration/history docs when
+  system-layer behavior, boundaries, or consolidation wording changes.
 - Update `.github/copilot-instructions.md` and relevant
   `.github/instructions/*.instructions.md` when review rules, repository
   structure, naming style, validation, or automation expectations change.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@ and `go-task`.
 
 [![ansible](https://github.com/tenhishadow/dotfiles/actions/workflows/ansible.yml/badge.svg)](https://github.com/tenhishadow/dotfiles/actions/workflows/ansible.yml)
 
-The default workflow is intentionally user-level only: it links files from
-`dotfiles/` into `$HOME` and does not require sudo. System-wide configuration
-is available through explicit opt-in tasks.
+This repository contains the user-level dotfiles workflow and the former
+`ans-workstation` system automation layer. The default workflow remains
+intentionally user-level and sudo-free: it links managed files from
+`dotfiles/` into `$HOME`. System-wide workstation configuration and browser/VS
+Code policies are available only through explicit opt-in playbooks and
+`go-task` targets.
 
 ## Requirements
 
@@ -40,6 +43,28 @@ _INSTALL_DIR="$HOME/.dotfiles" \
 directories, links managed payload files, and removes a small set of explicit
 legacy user config paths.
 
+## Project Evolution
+
+`tenhishadow/ans-workstation` previously contained the standalone Arch Linux
+workstation automation. That layer has been consolidated into this repository.
+The consolidation did not change the execution boundary:
+
+- `go-task` / `playbook_install.yml` remains user-level and sudo-free.
+- `go-task system` / `playbook_system.yml` applies the opt-in system layer.
+- `go-task browser-policies` / `playbook_browser_policies.yml` applies the
+  opt-in browser and VS Code policy layer.
+
+The default dotfiles install path must not apply privileged configuration.
+
+## Execution Layers
+
+| Layer | Command | Privileged | Purpose |
+| ---- | ------- | ---------- | ------- |
+| User dotfiles | `go-task` | No | Link managed dotfiles into `$HOME`. |
+| System workstation | `go-task system:check` / `go-task system` | Yes | Check or apply the opt-in Arch Linux workstation layer. |
+| Browser policies | `go-task browser-policies:check` / `go-task browser-policies` | Yes | Check or apply opt-in browser and VS Code policies. |
+| Validation | `go-task verify` | No direct system apply | Run repository validation, linting, documentation checks, and smoke tests. |
+
 ## Repository Layout
 
 | Path | Purpose |
@@ -52,9 +77,20 @@ legacy user config paths.
 | `roles/dotfiles/` | User-level dotfiles validation and symlink role. |
 | `roles/system/` | Arch Linux workstation system provisioning role. |
 | `roles/browser_policies/` | Enterprise browser and VS Code policy role. |
-| `docs/` | Generated operator manuals, including Neovim keymaps. |
+| `docs/` | Architecture, adoption, security, migration, and generated operator manuals. |
 | `.github/` | GitHub Actions, issue forms, PR template, labeler, and release automation. |
 | `.test/` | Isolated smoke-test fixtures and container test entry points. |
+
+## Documentation
+
+| Document | Purpose |
+| -------- | ------- |
+| [`docs/architecture.md`](docs/architecture.md) | Repository layer model and safety boundaries. |
+| [`docs/adoption.md`](docs/adoption.md) | Practical first-use and forking notes. |
+| [`docs/security-notes.md`](docs/security-notes.md) | Security caveats for this personal workstation baseline. |
+| [`docs/migration-from-ans-workstation.md`](docs/migration-from-ans-workstation.md) | Location map for the former `ans-workstation` layer. |
+| [`roles/system/README.md`](roles/system/README.md) | System role managed paths, validation, and rollback notes. |
+| [`roles/browser_policies/README.md`](roles/browser_policies/README.md) | Browser and VS Code policy targets, variables, and rollback notes. |
 
 ## Common Tasks
 
@@ -144,7 +180,7 @@ accidental conflicts:
 | ---- | ---- |
 | `inventory/host_vars/this_host/dotfiles.yml` | User-level mappings, extra directories, and cleanup paths. |
 | `inventory/host_vars/this_host/system.yml` | Non-security system settings such as MOTD and journald. |
-| `inventory/host_vars/this_host/security.yml` | SSHD, sysctl, and limits hardening settings. |
+| `inventory/host_vars/this_host/security.yml` | SSHD, sysctl, and limits security-sensitive workstation settings. |
 | `inventory/host_vars/this_host/browser_policies.yml` | Browser and VS Code policy overrides. |
 
 Keep host variables role-prefixed: `dotfiles_*`, `system_*`, or

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The default dotfiles install path must not apply privileged configuration.
 | Command | Purpose |
 | ------- | ------- |
 | `go-task` | Apply user-level dotfiles only. |
+| `go-task dotfiles:check` | Dry-run the user-level dotfiles playbook with diff output. |
 | `go-task lint` | Run `ansible-lint` for playbooks, inventory, and roles. |
 | `go-task yamllint` | Run YAML linting through the pinned `uv` environment. |
 | `go-task vint` | Run Vint with Neovim syntax enabled for Vimscript payloads. |
@@ -202,7 +203,7 @@ sudo. It manages Arch Linux packages, system drop-ins, selected `/etc`
 configuration, sysctl values, PAM limits, Docker daemon and overlay settings,
 cron, reflector, and laptop-related settings.
 
-The system role ships conservative default tuning for workstation use:
+The system role ships role-owned default tuning for workstation use:
 
 - sysctl defaults for unprivileged BPF, `fq`, BBR, `somaxconn`, and local port
   range.
@@ -254,7 +255,7 @@ Docker is unavailable and state that limitation in review notes.
 
 Additional checks by area:
 
-- User dotfiles or symlink mappings: `go-task`
+- User dotfiles or symlink mappings: `go-task dotfiles:check`, then `go-task`
 - Full local validation, including Super-Linter and JSCPD: `go-task verify`
 - Vimscript payloads: `go-task vint`
 - Neovim keymap docs: `go-task docs:nvim-keymaps:check`

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The default dotfiles install path must not apply privileged configuration.
 | [`docs/adoption.md`](docs/adoption.md) | Practical first-use and forking notes. |
 | [`docs/security-notes.md`](docs/security-notes.md) | Security caveats for this personal workstation baseline. |
 | [`docs/migration-from-ans-workstation.md`](docs/migration-from-ans-workstation.md) | Location map for the former `ans-workstation` layer. |
+| [`docs/github-labels.md`](docs/github-labels.md) | GitHub labeler pipeline and repository label expectations. |
 | [`roles/system/README.md`](roles/system/README.md) | System role managed paths, validation, and rollback notes. |
 | [`roles/browser_policies/README.md`](roles/browser_policies/README.md) | Browser and VS Code policy targets, variables, and rollback notes. |
 
@@ -272,7 +273,8 @@ Additional checks by area:
 
 GitHub issue forms and the PR template live under `.github/`. The labeler is
 path-based and mirrors the current repository structure, including dotfiles,
-inventory, roles, tests, automation, and AI instructions.
+inventory, roles, tests, automation, and AI instructions. Label expectations
+are documented in [`docs/github-labels.md`](docs/github-labels.md).
 
 GitHub Copilot review guidance lives in `.github/copilot-instructions.md`,
 with path-specific rules under `.github/instructions/`.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -203,6 +203,9 @@ tasks:
   default:
     deps: [deps-galaxy]
     cmd: "{{.MITOGEN_VARS}} {{.RUN_PLAYBOOK}}"
+  dotfiles:check:
+    deps: [deps-galaxy]
+    cmd: "{{.MITOGEN_VARS}} {{.RUN_PLAYBOOK}} --check --diff"
   system:
     deps: [deps-galaxy]
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -134,7 +134,9 @@ tasks:
     cmd: "uv run yamllint ."
   vint:
     deps: [deps-python]
-    cmd: "PYTHONWARNINGS=ignore uv run vint --enable-neovim {{.VINT_TARGETS}}"
+    cmd: >-
+      PYTHONWARNINGS=ignore
+      uv run python .test/vint_runner.py --enable-neovim {{.VINT_TARGETS}}
   stylua:
     deps: [deps-verify]
     cmd: "stylua --check {{.STYLUA_TARGETS}}"

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,6 @@
 [defaults]
 system_warnings      = True
 deprecation_warnings = True
-command_warnings     = True
 retry_files_enabled  = False
 inventory            = ./inventory
 interpreter_python   = auto_silent

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -1,0 +1,39 @@
+# Adoption Guide
+
+The safe first command is:
+
+```bash
+go-task
+```
+
+That command applies only the user-level dotfiles workflow. It runs
+`playbook_install.yml`, links managed files from `dotfiles/` into `$HOME`, and
+does not apply system-wide configuration.
+
+Do not blindly run these privileged apply commands:
+
+```bash
+go-task system
+go-task browser-policies
+```
+
+Run check mode first:
+
+```bash
+go-task system:check
+go-task browser-policies:check
+```
+
+Review these host values before privileged use:
+
+- `inventory/host_vars/this_host/dotfiles.yml`
+- `inventory/host_vars/this_host/system.yml`
+- `inventory/host_vars/this_host/security.yml`
+- `inventory/host_vars/this_host/browser_policies.yml`
+
+The local host values are personal workstation choices. They are not a generic
+security baseline and should not be copied to servers, shared systems, or other
+workstations without review.
+
+For a fork, start by adjusting inventory values and dotfile mappings, then run
+the check targets before applying any privileged layer.

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -1,6 +1,18 @@
 # Adoption Guide
 
-The safe first command is:
+The lowest-risk first check is:
+
+```bash
+go-task dotfiles:check
+```
+
+That command runs the user-level dotfiles playbook in check mode with diff
+output. It is sudo-free and does not apply system-wide configuration.
+
+Review `inventory/host_vars/this_host/dotfiles.yml` before applying the
+user-level workflow on another account or fork.
+
+The user-level apply command is:
 
 ```bash
 go-task
@@ -8,7 +20,8 @@ go-task
 
 That command applies only the user-level dotfiles workflow. It runs
 `playbook_install.yml`, links managed files from `dotfiles/` into `$HOME`, and
-does not apply system-wide configuration.
+does not apply system-wide configuration. It can still replace managed
+destinations with symlinks and remove explicit legacy user paths.
 
 Do not blindly run these privileged apply commands:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,41 @@
+# Architecture
+
+This repository is a personal Arch Linux dotfiles and workstation automation
+baseline managed with Ansible, `uv`, and `go-task`.
+
+It keeps user-owned dotfiles, opt-in system provisioning, opt-in browser and VS
+Code policies, and repository validation in one place without changing the
+default execution boundary.
+
+## Layer Model
+
+| Layer | Entry points | Purpose |
+| ----- | ------------ | ------- |
+| User dotfiles | `go-task`, `playbook_install.yml`, `roles/dotfiles/` | Link managed files from `dotfiles/` into `$HOME` and remove explicit legacy user paths. |
+| System workstation | `go-task system:check`, `go-task system`, `playbook_system.yml`, `roles/system/` | Check or apply the opt-in Arch Linux workstation layer. |
+| Browser and VS Code policies | `go-task browser-policies:check`, `go-task browser-policies`, `playbook_browser_policies.yml`, `roles/browser_policies/` | Check or apply opt-in system policy files under `/etc`. |
+| Validation and dependencies | `Taskfile.yml`, `.github/`, Renovate, `uv.lock` | Keep local validation, CI, linting, dependency updates, and generated docs reproducible. |
+
+Host-specific values live under `inventory/host_vars/this_host/` and stay split
+by ownership: dotfiles mappings, system settings, security-sensitive
+workstation settings, and browser policy overrides.
+
+## Safety Model
+
+- The default `go-task` path runs `playbook_install.yml` only and is sudo-free.
+- Privileged workstation and policy layers require explicit commands.
+- System configuration prefers drop-ins and snippets where upstream supports
+  them.
+- Cleanup and removal paths should stay explicit, narrow, and reviewable.
+- Check mode is available for privileged layers through `go-task system:check`
+  and `go-task browser-policies:check`.
+
+## Former ans-workstation Layer
+
+The former standalone `tenhishadow/ans-workstation` automation has been
+consolidated into this repository as the opt-in system workstation layer.
+
+The main locations are `roles/system/`, `playbook_system.yml`, and the
+`system.yml` and `security.yml` host var files under
+`inventory/host_vars/this_host/`. The default dotfiles install path remains
+separate and must not apply system-wide configuration.

--- a/docs/github-labels.md
+++ b/docs/github-labels.md
@@ -1,0 +1,43 @@
+# GitHub Labels
+
+GitHub labels are repository metadata. Pull request path labels are declared in
+`.github/labeler.yml` and applied by `.github/workflows/labeler.yml`.
+
+## Pipeline
+
+- The labeler workflow runs on pull requests.
+- `.github/labeler.yml` is the source for path-based label rules.
+- `sync-labels: false` preserves manually added labels and issue-form labels.
+- `changed-files-labels-limit` must stay above the number of path labels a
+  broad maintenance pull request can match. If that limit is exceeded,
+  `actions/labeler` skips all changed-file labels.
+
+## Path Labels
+
+Keep these GitHub labels present when editing `.github/labeler.yml`:
+
+| Label | Purpose |
+| ----- | ------- |
+| `ai-instructions` | AI agent and Copilot instruction changes. |
+| `ansible` | Ansible playbooks, inventory, roles, or Galaxy requirements. |
+| `automation` | Repository automation, Taskfile, Renovate, or release tooling. |
+| `browser-policies` | Browser and VS Code enterprise policy automation. |
+| `ci` | GitHub Actions and CI configuration. |
+| `dependencies` | Dependency manifests, lockfiles, or update automation. |
+| `documentation` | Documentation and Markdown changes. |
+| `dotfiles` | User-level dotfiles payload or install flow. |
+| `github` | GitHub repository metadata, templates, or workflows. |
+| `inventory` | Ansible inventory and host variable ownership. |
+| `nvim` | Neovim configuration, fixtures, or generated keymap docs. |
+| `security` | Security-sensitive settings, SSHD, sysctl, or policy surfaces. |
+| `shell` | Shell startup files or shell test fixtures. |
+| `system` | Opt-in Arch Linux workstation system role. |
+| `tests` | Test fixtures, smoke tests, or validation harnesses. |
+
+## Template Labels
+
+Issue forms also use static labels such as `bug`, `enhancement`,
+`maintenance`, and `triage`. Keep those labels present in GitHub when changing
+issue templates.
+
+Release Please uses `autorelease: pending` and `autorelease: tagged`.

--- a/docs/migration-from-ans-workstation.md
+++ b/docs/migration-from-ans-workstation.md
@@ -1,0 +1,20 @@
+# Migration From ans-workstation
+
+The old standalone repository was `tenhishadow/ans-workstation`.
+
+The workstation automation now lives in this repository as the opt-in system
+layer:
+
+| Old concern | New location |
+| ----------- | ------------ |
+| System role | `roles/system/` |
+| System playbook | `playbook_system.yml` |
+| System host values | `inventory/host_vars/this_host/system.yml` |
+| Security-sensitive host values | `inventory/host_vars/this_host/security.yml` |
+| Check system layer | `go-task system:check` |
+| Apply system layer | `go-task system` |
+| Test system role | `go-task test:system` |
+
+The default `go-task` command in this repository does not apply system-wide
+configuration. It runs `playbook_install.yml` and remains limited to the
+user-level dotfiles workflow.

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -1,0 +1,20 @@
+# Security Notes
+
+This repository is a personal Arch Linux workstation baseline, not a generic
+hardening benchmark.
+
+Some settings optimize for local workstation usability and may not be
+appropriate for servers, shared systems, or regulated environments. Review the
+intent and impact before applying privileged layers.
+
+Review especially:
+
+- SSHD authentication and session settings
+- Docker group membership
+- IPv6 disablement
+- Browser extension and policy settings
+- Sysctl tuning
+- Package installation in the opt-in system layer
+
+Do not treat these values as universally secure. Adapt them to the host, threat
+model, users, and operational requirements.

--- a/dotfiles/.config/nvim/lazy-lock.json
+++ b/dotfiles/.config/nvim/lazy-lock.json
@@ -4,7 +4,7 @@
   "conform.nvim": { "branch": "master", "commit": "18aeab3d63d350dcf44d64c462cc489a3412af40" },
   "editorconfig-vim": { "branch": "master", "commit": "c0227885a06b155d5aa5465e08b9800e8c939f70" },
   "friendly-snippets": { "branch": "main", "commit": "6cd7280adead7f586db6fccbd15d2cac7e2188b9" },
-  "fzf": { "branch": "master", "commit": "e0d081906fd7a31b656b1d022042abcd1dcc0927" },
+  "fzf": { "branch": "master", "commit": "fcc3c6acce5cf4851b44c6299fe255519990bce6" },
   "fzf.vim": { "branch": "master", "commit": "b9624aa012ddcbae9e79964bfd30cc1fbe3cf263" },
   "gitsigns.nvim": { "branch": "main", "commit": "dd3f588bacbeb041be6facf1742e42097f62165d" },
   "gruvbox": { "branch": "master", "commit": "697c00291db857ca0af00ec154e5bd514a79191f" },

--- a/inventory/AGENTS.md
+++ b/inventory/AGENTS.md
@@ -11,8 +11,8 @@ playbooks.
 - `host_vars/this_host/dotfiles.yml` owns dotfile mappings and cleanup.
 - `host_vars/this_host/browser_policies.yml` owns browser policy overrides.
 - `host_vars/this_host/system.yml` owns non-security system role values.
-- `host_vars/this_host/security.yml` owns SSHD, sysctl, and limits hardening
-  values.
+- `host_vars/this_host/security.yml` owns SSHD, sysctl, and limits
+  security-sensitive workstation values.
 - New payload files under `../dotfiles/` must be added to
   `dotfiles_mapping` before the default playbook can link them.
 - System role values are used only by `playbook_system.yml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "mitogen",
     "yamllint",
     "vim-vint>=0.3.21",
-    "setuptools<83",
+    "setuptools<81",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ dependencies = [
     "ansible",
     "mitogen",
     "yamllint",
-    "vim-vint>=0.3.21",
-    "setuptools<81",
+    "vim-vint",
 ]
 
 [tool.uv]

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,7 @@
 collections:
+  - name: community.general
+    version: "12.6.0"
+    source: https://galaxy.ansible.com
   - name: serverscom.mitogen
     version: "1.4.1"
     source: https://galaxy.ansible.com

--- a/roles/browser_policies/tasks/chromium.yml
+++ b/roles/browser_policies/tasks/chromium.yml
@@ -1,8 +1,9 @@
 ---
-- name: Chromium Policies | Build managed targets
-  ansible.builtin.set_fact:
-    browser_policies_policy_files: "{{ browser_policies_chromium_policy_files }}"
+- name: Chromium Policies | Run policy file tasks
+  ansible.builtin.include_tasks:
+    file: policy-files.yml
   vars:
+    browser_policies_policy_files: "{{ browser_policies_chromium_policy_files }}"
     browser_policies_chromium_extension_settings_merged: >-
       {{
         browser_policies_extension_block
@@ -47,9 +48,5 @@
       {%-   endif -%}
       {%- endfor -%}
       {{ browser_policies_chromium_files }}
-
-- name: Chromium Policies | Run policy file tasks
-  ansible.builtin.include_tasks:
-    file: policy-files.yml
   when:
-    - browser_policies_policy_files | length > 0
+    - browser_policies_chromium_policy_files | length > 0

--- a/roles/browser_policies/tasks/firefox.yml
+++ b/roles/browser_policies/tasks/firefox.yml
@@ -1,8 +1,9 @@
 ---
-- name: Firefox Policies | Build managed targets
-  ansible.builtin.set_fact:
-    browser_policies_policy_files: "{{ browser_policies_firefox_policy_files }}"
+- name: Firefox Policies | Run policy file tasks
+  ansible.builtin.include_tasks:
+    file: policy-files.yml
   vars:
+    browser_policies_policy_files: "{{ browser_policies_firefox_policy_files }}"
     browser_policies_firefox_extension_settings_merged: >-
       {{
         browser_policies_extension_block
@@ -46,9 +47,5 @@
       {%-   endif -%}
       {%- endfor -%}
       {{ browser_policies_firefox_files }}
-
-- name: Firefox Policies | Run policy file tasks
-  ansible.builtin.include_tasks:
-    file: policy-files.yml
   when:
-    - browser_policies_policy_files | length > 0
+    - browser_policies_firefox_policy_files | length > 0

--- a/roles/browser_policies/tasks/vscode.yml
+++ b/roles/browser_policies/tasks/vscode.yml
@@ -1,8 +1,9 @@
 ---
-- name: VS Code Policies | Build managed targets
-  ansible.builtin.set_fact:
-    browser_policies_policy_files: "{{ browser_policies_vscode_policy_files }}"
+- name: VS Code Policies | Run policy file tasks
+  ansible.builtin.include_tasks:
+    file: policy-files.yml
   vars:
+    browser_policies_policy_files: "{{ browser_policies_vscode_policy_files }}"
     browser_policies_vscode_policy_files: >-
       {%- set browser_policies_vscode_files = [] -%}
       {%- for browser_policies_vscode_target in browser_policies_vscode_targets -%}
@@ -37,9 +38,5 @@
       {%-   endif -%}
       {%- endfor -%}
       {{ browser_policies_vscode_files }}
-
-- name: VS Code Policies | Run policy file tasks
-  ansible.builtin.include_tasks:
-    file: policy-files.yml
   when:
-    - browser_policies_policy_files | length > 0
+    - browser_policies_vscode_policy_files | length > 0

--- a/roles/system/AGENTS.md
+++ b/roles/system/AGENTS.md
@@ -3,6 +3,8 @@
 Applies to `roles/system/`.
 
 This is the opt-in Arch Linux workstation system provisioning role.
+It contains the system automation consolidated from the former
+`tenhishadow/ans-workstation` repository.
 
 ## Role Flow
 
@@ -39,6 +41,8 @@ Keep the high-level flow predictable:
 - Keep `backup: true` when a task already uses it.
 - Keep handler-driven service restarts.
 - Keep task names, comments, templates, and documentation in English.
+- Keep role documentation and migration/history wording aligned when the
+  system layer behavior, managed paths, or consolidation notes change.
 - Do not change system package lists here; package list rules live in
   `vars/AGENTS.md`.
 - Do not commit secrets, private keys, tokens, generated configs, or local

--- a/roles/system/README.md
+++ b/roles/system/README.md
@@ -63,7 +63,8 @@ The role keeps privileged behavior explicit and guarded:
 
 1. Validate the supported OS.
 2. Load distro-specific vars and packages.
-3. Derive CI, container, virtual machine, systemd, and timesyncd capability guards.
+3. Derive CI, container, virtual machine, systemd, user systemd, and timesyncd
+   capability guards.
 4. Validate public role variables and host overrides.
 5. Install the package manifest under tag `pkg` when packages are enabled.
 6. Run time, locale, console, login, limits, cron, sysctl, journald, SSHD, OS,
@@ -144,6 +145,8 @@ Public role variables use the `system_` prefix. Use `system_journald_settings`,
 their keys intentionally preserve upstream config option names. The role-owned
 `system_sysctl_default_settings` map contains default kernel tuning, while
 `system_sysctl_settings` is for host-specific additions and overrides.
+User service files are owned by `system_user_service_owner` and
+`system_user_service_group`, which default to the real user and group facts.
 
 Example host overrides:
 

--- a/roles/system/README.md
+++ b/roles/system/README.md
@@ -7,6 +7,13 @@ paths and services. It is intentionally not part of the default dotfiles
 workflow. Run it only through `playbook_system.yml` or the matching `go-task`
 targets.
 
+## Historical Note
+
+This role supersedes the former standalone `tenhishadow/ans-workstation`
+automation layer. Legacy `*-ans-workstation.conf` drop-ins are removed where
+applicable to avoid duplicate settings after consolidation. The role remains
+opt-in and is not part of the default dotfiles workflow.
+
 ## Usage
 
 Review the task list:

--- a/roles/system/defaults/main.yml
+++ b/roles/system/defaults/main.yml
@@ -57,6 +57,8 @@ system_config_private_file_mode: "0600"
 system_config_dir_mode: "0755"
 system_user_systemd_dir_mode: "0700"
 system_user_service_file_mode: "0640"
+system_user_service_owner: "{{ ansible_facts.real_user_id }}"
+system_user_service_group: "{{ ansible_facts.real_group_id }}"
 
 system_container_virtualization_types:
   - container

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -53,6 +53,18 @@
   tags:
     - always
 
+- name: System | Set user systemd guard
+  ansible.builtin.set_fact:
+    system_can_manage_user_systemd: >-
+      {{
+        system_user_services_enabled | bool
+        and ansible_facts.service_mgr == "systemd"
+        and not (system_is_container | bool)
+        and not (system_in_ci | bool)
+      }}
+  tags:
+    - always
+
 - name: System | Set timesyncd guard
   ansible.builtin.set_fact:
     system_can_manage_timesyncd: >-

--- a/roles/system/tasks/user-services.yml
+++ b/roles/system/tasks/user-services.yml
@@ -3,8 +3,8 @@
   ansible.builtin.file:
     path: "{{ system_user_systemd_dir }}"
     state: directory
-    owner: "{{ ansible_facts.user_id }}"
-    group: "{{ ansible_facts.user_id }}"
+    owner: "{{ system_user_service_owner }}"
+    group: "{{ system_user_service_group }}"
     mode: "{{ system_user_systemd_dir_mode }}"
 
 - name: User systemd | Write ssh-agent service
@@ -13,8 +13,8 @@
     src: templates/ssh-agent.service.j2
     dest: "{{ system_ssh_agent_service_path }}"
     backup: true
-    owner: "{{ ansible_facts.user_id }}"
-    group: "{{ ansible_facts.user_id }}"
+    owner: "{{ system_user_service_owner }}"
+    group: "{{ system_user_service_group }}"
     mode: "{{ system_user_service_file_mode }}"
   when:
     - ansible_facts.service_mgr == "systemd"
@@ -30,4 +30,4 @@
     enabled: true
     daemon_reload: true
   when:
-    - system_can_manage_systemd | bool
+    - system_can_manage_user_systemd | bool

--- a/roles/system/tasks/validate.yml
+++ b/roles/system/tasks/validate.yml
@@ -37,6 +37,8 @@
       - system_config_dir_mode is string
       - system_user_systemd_dir_mode is string
       - system_user_service_file_mode is string
+      - system_user_service_owner is string or system_user_service_owner is number
+      - system_user_service_group is string or system_user_service_group is number
       - system_container_virtualization_types is sequence
       - system_container_virtualization_types is not string
       - system_pacman_parallel_downloads is number

--- a/roles/system/vars/archlinux-packages.yml
+++ b/roles/system/vars/archlinux-packages.yml
@@ -44,14 +44,14 @@ system_packages:
   - openbsd-netcat
   # : }}}
 
-  # : network {{{
-  ## messages
+  # : communication {{{
+  ## Messaging
   - element-desktop
   - telegram-desktop
   - mattermost
   # - zoom # AUR
   # - slack-desktop # AUR
-  ## browsers
+  ## Browsers
   - firefox
   # - brave-bin # AUR
   # : }}}

--- a/uv.lock
+++ b/uv.lock
@@ -265,7 +265,6 @@ dependencies = [
     { name = "ansible" },
     { name = "ansible-lint" },
     { name = "mitogen" },
-    { name = "setuptools" },
     { name = "vim-vint" },
     { name = "yamllint" },
 ]
@@ -275,8 +274,7 @@ requires-dist = [
     { name = "ansible" },
     { name = "ansible-lint" },
     { name = "mitogen" },
-    { name = "setuptools", specifier = "<81" },
-    { name = "vim-vint", specifier = ">=0.3.21" },
+    { name = "vim-vint" },
     { name = "yamllint" },
 ]
 
@@ -523,15 +521,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "80.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -275,7 +275,7 @@ requires-dist = [
     { name = "ansible" },
     { name = "ansible-lint" },
     { name = "mitogen" },
-    { name = "setuptools", specifier = "<83" },
+    { name = "setuptools", specifier = "<81" },
     { name = "vim-vint", specifier = ">=0.3.21" },
     { name = "yamllint" },
 ]
@@ -527,11 +527,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "80.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary

- Document the repository as a unified personal Arch Linux dotfiles and workstation automation baseline.
- Add architecture, adoption, security, and migration notes for the former `tenhishadow/ans-workstation` system layer.
- Add `go-task dotfiles:check` for a sudo-free user-level dry-run of `playbook_install.yml`.
- Improve Ansible hygiene by declaring required Galaxy collections, removing stale config, clarifying user service ownership, and localizing browser policy file variables.
- Keep Python tool dependencies unpinned in `pyproject.toml`, keep resolved versions in `uv.lock`, and keep Vint validation working without adding `setuptools` back to project dependencies.
- Refresh the Neovim lazy lock for `fzf` and document the Vint runner fixture.
- Stabilize the path labeler for broad maintenance PRs, sync GitHub labels, expand security-sensitive path coverage, and document label expectations.
- Keep package contents, SSHD values, sysctl values, browser policy values, Neovim runtime config, and dotfiles mappings unchanged.

# Scope

- [ ] User-level dotfiles only
- [x] Inventory or Ansible plumbing
- [x] Opt-in system role
- [x] Browser or VS Code policies
- [x] Neovim lockfile
- [x] CI, release, or repository tooling
- [x] Documentation or AI instructions

# Release

- [x] PR title is a release-please eligible Conventional Commit: `feat(workstation): consolidate workstation automation`.
- [x] Repository settings allow only squash merge and use the PR title as the squash commit title.
- [x] To produce the next release, squash merge this PR with the title unchanged, then merge the release-please PR created on `master`.

# Validation

- [x] `git diff --check`
- [x] `uv lock --check`
- [x] `go-task deps-galaxy`
- [x] `go-task yamllint`
- [x] `go-task lint`
- [x] `go-task vint`
- [x] `go-task dotfiles:check`
- [x] `go-task system:check`
- [x] `go-task browser-policies:check`
- [x] `go-task docs:nvim-keymaps:check`
- [x] `go-task test:nvim`
- [x] `go-task test:system`
- [x] `go-task verify`
- [x] `uv run ansible-config dump --only-changed`
- [x] `uv run ansible-config list | grep -i command_warnings || true`
- [x] GitHub PR checks are green.

# Safety

- [x] Default `go-task` remains user-level and does not require sudo.
- [x] `playbook_install.yml` remains limited to `roles/dotfiles`.
- [x] Privileged system and browser policy behavior remains explicit and opt-in.
- [x] No privileged apply command was run on the host.
- [x] No secrets, tokens, runtime state, caches, profiles, or generated workspaces are committed.
- [x] System config changes continue to prefer drop-ins where supported.
- [x] PAM limits and kernel module options continue to use `limits.d` and `modprobe.d` snippets.
- [x] Ansible variables follow role prefixes and settings-map casing rules.
- [x] Role input variables are validated where the role exposes a contract.
- [x] README, docs, AGENTS, Copilot, and `.github/instructions/` guidance are aligned with the new execution boundary.
- [x] Versioned automation dependencies remain covered by Renovate or resolved in lockfiles.

# Notes

- `go-task verify` includes the default user-level `go-task` path, plus `system:check`, `browser-policies:check`, and Super-Linter.
- `go-task test:system` applies the system role only inside a disposable Arch Linux Docker container and verifies idempotency on the second pass.
- The latest labeler run applied the expected path labels to this PR. Label expectations are documented in `docs/github-labels.md`.