### PR TITLE
chore(safety): improve automation reversibility

### DIFF
--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,5 +1,9 @@
 rules:
+  # GitHub Actions versions are Renovate-managed and reviewed in normal PRs,
+  # so this repo does not require immutable action SHAs in workflow files.
   unpinned-uses:
     disable: true
+  # Workflows do not execute untrusted user-provided template values; current
+  # expressions are limited to trusted repository and GitHub event metadata.
   template-injection:
     disable: true

--- a/README.md
+++ b/README.md
@@ -29,19 +29,48 @@ sudo pacman -Sy --noconfirm --needed git go-task uv
 
 ## Quick Start
 
-Clone and apply the user-level dotfiles:
+Clone the repository:
 
 ```bash
 _INSTALL_DIR="$HOME/.dotfiles" \
   && git clone https://github.com/tenhishadow/dotfiles.git "$_INSTALL_DIR" \
-  && cd "$_INSTALL_DIR" \
-  && go-task
+  && cd "$_INSTALL_DIR"
+```
+
+Start with the user-level dry run:
+
+```bash
+go-task dotfiles:check
+```
+
+Apply the user-level dotfiles:
+
+```bash
+go-task
 ```
 
 `go-task` runs `playbook_install.yml` only. That playbook loads
 `roles/dotfiles`, validates the dotfiles contract, creates required user
 directories, links managed payload files, and removes a small set of explicit
 legacy user config paths.
+
+## First-Run Safety
+
+`go-task dotfiles:check` runs the default Ansible playbook in check mode with
+diff output. The default playbook is user-level, uses `become: false`, and
+loads `roles/dotfiles` only. It does not apply privileged system or browser
+policy configuration.
+
+Taskfile dependency bootstrap runs before Ansible and may install missing local
+prerequisites such as `uv` or `git` through `pacman` and `sudo` on Arch Linux.
+The dotfiles workflow can still replace managed destinations with symlinks and
+remove explicit legacy user paths, so review
+`inventory/host_vars/this_host/dotfiles.yml` before applying it on another
+account or fork.
+
+Do not run `go-task system` or `go-task browser-policies` until you have
+reviewed managed `/etc` paths, Docker group behavior, SSHD/sysctl values, the
+system package manifest, and browser/VS Code policy ownership.
 
 ## Project Evolution
 
@@ -64,6 +93,9 @@ The default dotfiles install path must not apply privileged configuration.
 | System workstation | `go-task system:check` / `go-task system` | Yes | Check or apply the opt-in Arch Linux workstation layer. |
 | Browser policies | `go-task browser-policies:check` / `go-task browser-policies` | Yes | Check or apply opt-in browser and VS Code policies. |
 | Validation | `go-task verify` | No direct system apply | Run repository validation, linting, documentation checks, and smoke tests. |
+
+Check targets run after Taskfile dependency bootstrap. `go-task system:check`
+then runs `playbook_system.yml` in Ansible check mode with diff output.
 
 ## Repository Layout
 
@@ -110,7 +142,7 @@ The default dotfiles install path must not apply privileged configuration.
 | `go-task test:nvim:mason-tools` | Validate configured Mason package names against the Mason registry. |
 | `go-task test:nvim:profile` | Run the Neovim smoke test, then print startup and loaded-plugin counts. |
 | `go-task system:list` | List tasks in the opt-in system playbook. |
-| `go-task system:check` | Dry-run the opt-in system playbook. |
+| `go-task system:check` | Bootstrap dependencies, then dry-run the opt-in system playbook. |
 | `go-task system` | Apply the opt-in system playbook. |
 | `go-task test:system` | Run the system role smoke and idempotency test in an Arch Linux container. |
 | `go-task browser-policies:check` | Dry-run system browser and VS Code policy management. |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -307,6 +307,7 @@ tasks:
         '+lua local cfg=require("lazy.core.config"); local names={}; local total=0; for name,p in pairs(cfg.plugins) do total=total+1; if p._ and p._.loaded then table.insert(names,name) end end; table.sort(names); print("plugins_total=" .. total); print("plugins_loaded=" .. #names); print("loaded_plugins=" .. table.concat(names,","))'
         +qa
   test:system:
+    deps: [deps-docker]
     cmd: >-
       docker run --rm -i
       -v "$(pwd):/.dotfiles:ro"

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -7,7 +7,10 @@ go-task dotfiles:check
 ```
 
 That command runs the user-level dotfiles playbook in check mode with diff
-output. It is sudo-free and does not apply system-wide configuration.
+output. The Ansible playbook is sudo-free and uses `become: false`, but
+Taskfile dependency bootstrap may install missing local prerequisites such as
+`uv` or `git` through `pacman` and `sudo` on Arch Linux before Ansible runs.
+It does not apply system-wide configuration.
 
 Review `inventory/host_vars/this_host/dotfiles.yml` before applying the
 user-level workflow on another account or fork.
@@ -36,6 +39,9 @@ Run check mode first:
 go-task system:check
 go-task browser-policies:check
 ```
+
+`go-task system:check` runs Ansible check mode for the opt-in system playbook
+after Taskfile dependency bootstrap.
 
 Review these host values before privileged use:
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,7 @@
 collections:
+  - name: ansible.posix
+    version: "2.1.0"
+    source: https://galaxy.ansible.com
   - name: community.general
     version: "12.6.1"
     source: https://galaxy.ansible.com

--- a/roles/browser_policies/README.md
+++ b/roles/browser_policies/README.md
@@ -32,7 +32,8 @@ The playbook uses sudo because policy files are system configuration.
 | VS Code | Owns the complete `/etc/vscode/policy.json` file for each enabled target. |
 
 System policy files should stay root-owned and should not be symlinked back
-into `$HOME`.
+into `$HOME`. Policy file writes create Ansible backups before replacing
+role-owned files.
 
 ## Variables
 
@@ -203,8 +204,9 @@ policy paths, and generated policy file specs before writing system files.
 
 ## Rollback
 
-Set `browser_policies_state: absent` for managed policy removal, or revert the
-role and inventory changes in git and reapply:
+Set `browser_policies_state: absent` for managed policy removal, inspect
+Ansible backups for replaced policy files, or revert the role and inventory
+changes in git and reapply:
 
 ```bash
 go-task browser-policies
@@ -219,4 +221,5 @@ profiles.
   code.
 - Password-manager policy changes do not necessarily delete passwords already
   saved in existing browser profiles.
-- Existing policy files at role-owned paths are replaced by rendered output.
+- Existing policy files at role-owned paths are backed up and replaced by
+  rendered output.

--- a/roles/browser_policies/tasks/policy-files.yml
+++ b/roles/browser_policies/tasks/policy-files.yml
@@ -41,7 +41,7 @@
     owner: "{{ browser_policies_owner }}"
     group: "{{ browser_policies_group }}"
     mode: "{{ browser_policies_file_mode }}"
-    backup: false
+    backup: true
   loop: "{{ browser_policies_policy_files }}"
   loop_control:
     loop_var: browser_policy_file

--- a/roles/system/README.md
+++ b/roles/system/README.md
@@ -51,7 +51,7 @@ go-task test:system
 | Locale and console | Manages `/etc/locale.gen`, `/etc/locale.conf`, and `/etc/vconsole.conf`. |
 | Sysctl | Applies `system_sysctl_default_settings` merged with `system_sysctl_settings` to `/etc/sysctl.d/999-ansible.conf` when `system_sysctl_enabled` is true. |
 | Limits | Writes `/etc/security/limits.d/10-dotfiles.conf` when `system_limits_enabled` is true. |
-| Pacman | Renders `/etc/pacman.conf` from the role template. |
+| Pacman | Renders `/etc/pacman.conf` from the role template with an Ansible backup before replacement. |
 | Reflector | Configures reflector and its systemd timer when systemd is available. |
 | Docker | Configures daemon settings and overlay module options when `system_docker_enabled` is true and the host is not CI/container. |
 | Laptop | Applies laptop-specific settings such as camera blacklist when `system_laptop_enabled` is true. |
@@ -210,8 +210,8 @@ git diff --check
 ## Rollback
 
 Use git to revert role changes before reapplying. For local system state,
-inspect Ansible backups for files rendered with `backup: true`, then apply the
-previous revision with:
+inspect Ansible backups for complete-file writes such as `/etc/pacman.conf`,
+then apply the previous revision with:
 
 ```bash
 go-task system

--- a/roles/system/tasks/archlinux-tasks.yml
+++ b/roles/system/tasks/archlinux-tasks.yml
@@ -4,6 +4,7 @@
   ansible.builtin.template:
     src: templates/pacman.conf.j2
     dest: "{{ system_pacman_config_path }}"
+    backup: true
     owner: "{{ system_config_owner }}"
     group: "{{ system_config_group }}"
     mode: "{{ system_config_file_mode }}"


### PR DESCRIPTION
## Summary

- Declare the `ansible.posix` Galaxy collection explicitly for `ansible.posix.sysctl` usage.
- Create Ansible backups before replacing role-owned `/etc/pacman.conf` and browser/VS Code policy files.
- Add the existing Docker preflight dependency to `go-task test:system`.
- Document first-run safety, Taskfile dependency bootstrap semantics, and `.zizmor.yml` trust assumptions.

## Validation

- [x] `git diff --check`
- [x] `go-task deps-galaxy`
- [x] `go-task yamllint`
- [x] `go-task lint` (passed; local Ansible collection/deprecation warnings only)
- [x] `go-task dotfiles:check`
- [x] `go-task system:check` (passed; check mode reported `tree-sitter-cli` would be installed)
- [x] `go-task browser-policies:check`
- [x] `go-task test:system` (Docker available; passed)

## Safety Notes

- No workstation setting values, host defaults, package names, SSHD/sysctl/Docker/browser policy/Neovim config, or cleanup rules were changed.
- No host privileged apply command was run. The system apply path ran only inside the `go-task test:system` container smoke test.