### PR TITLE
[codex] Ignore Renovate test fixtures

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,6 +62,8 @@ opt-in here.
 - Keep repository text, comments, task names, docs, and AI instructions in
   English.
 - Keep GitHub Actions least-privilege, deterministic, and Renovate-updateable.
+- Keep Renovate scoped to real dependency surfaces; `.test/` fixtures are not
+  Renovate-managed dependencies.
 - Leave `pyproject.toml` dependency constraints unpinned unless requested;
   `uv.lock` records resolved versions.
 - Keep labeler, templates, Renovate, and AI instructions aligned.

--- a/.github/instructions/github-automation.instructions.md
+++ b/.github/instructions/github-automation.instructions.md
@@ -15,6 +15,8 @@ applyTo: ".github/**/*.yml,.github/**/*.yaml,.github/**/*.md,renovate.json,Taskf
 - Ensure new versioned GitHub Actions, reusable workflows, Docker images,
   pre-commit hooks, Ansible collections, and future CI includes are detected by
   Renovate or documented as manually updated.
+- Keep Renovate scoped to real repository dependency surfaces. `.test/`
+  fixtures must stay ignored because they are detector and smoke-test inputs.
 - Keep dependency refresh tasks explicit: `go-task deps-upgrade` should update
   local lock/config surfaces such as `uv.lock`, pre-commit revs, Ansible Galaxy
   installed collections, and Neovim `lazy-lock.json`; GitHub Actions version

--- a/.test/AGENTS.md
+++ b/.test/AGENTS.md
@@ -42,6 +42,8 @@ source of truth:
 - Keep Neovim smoke fixture directories aligned with the `name` values in
   `.test/nvim/smoke.lua`.
 - Keep generated workspaces out of git.
+- Keep `.test/` excluded from Renovate because dependency-like files here are
+  fixtures, not repository dependency surfaces.
 - Keep Neovim test language lists sourced from the canonical config when
   possible, especially `config.languages`.
 - Keep Tree-sitter parser installation optional in the test sandbox and skip

--- a/README.md
+++ b/README.md
@@ -338,7 +338,9 @@ with path-specific rules under `.github/instructions/`.
 
 Renovate manages supported dependency updates for GitHub Actions, pre-commit,
 Ansible Galaxy requirements, the Python toolchain, and the Super-Linter Docker
-image referenced by `Taskfile.yml`.
+image referenced by `Taskfile.yml`. Renovate intentionally ignores `.test/`
+fixtures because they are detector and smoke-test inputs, not repository
+dependency surfaces.
 
 Use `go-task deps-upgrade` for local, reviewable dependency refreshes. It
 updates `uv.lock`, refreshes the installed Ansible Galaxy collections allowed by

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":dependencyDashboard"],
+  "enabledManagers": ["ansible-galaxy", "github-actions", "pep621", "pre-commit", "custom.regex"],
+  "ignorePaths": [".test/**"],
   "labels": ["dependencies"],
   "semanticCommits": "enabled",
   "semanticCommitType": "deps",
@@ -41,7 +43,7 @@
       "addLabels": ["ansible"]
     },
     {
-      "matchManagers": ["pep621", "uv"],
+      "matchManagers": ["pep621"],
       "groupName": "python toolchain"
     },
     {


### PR DESCRIPTION
## Summary

- Limit Renovate to the repository dependency surfaces that are actually maintained here.
- Ignore `.test/**` so detector and smoke-test fixtures do not show up in the Dependency Dashboard.
- Document the Renovate scope in README and AI instructions.

## Validation

- `git diff --check HEAD~1..HEAD`
- `go-task renovate`
- `LOG_LEVEL=debug npx --yes --package renovate renovate --platform=local --dry-run=extract --require-config=required`

The local extract reports only 8 package files: GitHub workflows, `requirements.yml`, `pyproject.toml`, `.pre-commit-config.yaml`, and `Taskfile.yml`.