### PR TITLE
feat(system): bootstrap yay from AUR

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -10,7 +10,7 @@ automation under `.github/`.
 - Keep workflow behavior aligned with `Taskfile.yml`.
 - Keep `go-task verify` aligned with local validation and review automation.
 - Keep the `task-all` CI job aligned with the explicit `go-task all` aggregate
-  apply target. It runs in an Arch Linux container and skips package
+  apply target. It runs in an Arch Linux container and skips package and AUR
   installation to keep CI bounded.
 - Do not reintroduce super-linter into the `go-task lint` path.
 - Do not casually change release-please, Renovate, CODEOWNERS, or zizmor

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,6 +28,8 @@ maintenance. Former `ans-workstation` automation is opt-in.
 - Dotfiles cron jobs that redirect to state logs create the state dir first.
 - System setting maps use `system_journald_settings`, `system_sshd_settings`,
   and `system_sysctl_settings`; preserve upstream key casing.
+- AUR helper/package management stays in `roles/system`, uses tag `aur`, and is
+  skipped in check mode, CI, and containers.
 - Prefer drop-ins over editing upstream main configs where supported.
 - Verify policy/privacy keys upstream; do not guess AI-client, browser,
   package-manager, or developer-tool settings.

--- a/.github/instructions/ansible.instructions.md
+++ b/.github/instructions/ansible.instructions.md
@@ -25,6 +25,8 @@ applyTo: "playbook_*.yml,inventory/**/*.yml,roles/**/*.yml,requirements.yml,ansi
 - Use `go-task dotfiles:check` for user-level dotfiles dry-runs.
 - Keep `roles/system` as the opt-in layer consolidated from the former
   `ans-workstation` automation; do not route it through default `go-task`.
+- Keep AUR helper/package management in `roles/system`, tagged `aur`, and
+  guarded from check-mode, CI, and container execution.
 - Dotfiles mapping entries must use `name`, relative `payload`, and absolute
   `dest`.
 - User cron jobs that redirect to managed state logs must create the state

--- a/.github/instructions/github-automation.instructions.md
+++ b/.github/instructions/github-automation.instructions.md
@@ -13,8 +13,9 @@ applyTo: ".github/**/*.yml,.github/**/*.yaml,.github/**/*.md,renovate.json,Taskf
 - Keep `go-task all` as an explicit apply target; it must not replace default
   `go-task` or `go-task verify`.
 - Keep the `task-all` CI job as an Arch Linux container check of
-  `go-task all -- --skip-tags pkg` so aggregate ordering is covered without
-  installing the full workstation package manifest on hosted runners.
+  `go-task all -- --skip-tags pkg,aur` so aggregate ordering is covered without
+  installing the full workstation package manifest or AUR helper on hosted
+  runners.
 - Do not reintroduce Super-Linter into `go-task lint`; it belongs to
   `go-task superlinter` and the aggregate `go-task verify` path.
 - Ensure new versioned GitHub Actions, reusable workflows, Docker images,

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -60,4 +60,4 @@ jobs:
           persist-credentials: false
 
       - name: Run aggregate target
-        run: go-task all -- --skip-tags pkg
+        run: go-task all -- --skip-tags pkg,aur

--- a/.test/system/exec.sh
+++ b/.test/system/exec.sh
@@ -100,7 +100,7 @@ sudo reflector \
 pacman --disable-sandbox -Sy --noconfirm --noprogressbar >/dev/null
 check_system_package_targets
 
-go-task system -- --skip-tags pkg
+go-task system -- --skip-tags pkg,aur
 
 # idempotency
-go-task system -- --skip-tags pkg
+go-task system -- --skip-tags pkg,aur

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@ Ansible, `uv`, and `go-task`.
   duplicating literals.
 - Keep package lists, policy target lists, and user-level privacy configs
   declarative.
+- Keep AUR helper/package management in `roles/system` task files tagged `aur`
+  and guarded from check-mode, CI, and container execution.
 - Use handlers for service restarts when template or config changes require
   them.
 - Preserve CI and container guards for privileged system behavior.

--- a/README.md
+++ b/README.md
@@ -270,13 +270,15 @@ go-task system
 This path runs `playbook_system.yml`, uses `roles/system`, and may require
 sudo. It manages Arch Linux packages, system drop-ins, selected `/etc`
 configuration, sysctl values, PAM limits, Docker daemon and overlay settings,
-cron, reflector, and laptop-related settings.
+cron, reflector, optional AUR `yay` bootstrap, and laptop-related settings.
 
 The system role ships role-owned default tuning for workstation use:
 
 - sysctl defaults for unprivileged BPF, `fq`, BBR, `somaxconn`, and local port
   range.
 - PAM limits through `/etc/security/limits.d/10-dotfiles.conf`.
+- AUR helper bootstrap through tasks tagged `aur`, skipped in check mode, CI,
+  and containers.
 - Docker overlay module options through `/etc/modprobe.d/99-dotfiles-overlay.conf`.
 
 Host-specific additions and overrides belong in
@@ -347,9 +349,9 @@ inventory, roles, tests, automation, and AI instructions. Label expectations
 are documented in [`docs/github-labels.md`](docs/github-labels.md).
 
 The `ansible` workflow also runs a `task-all` job in an Arch Linux container.
-It executes `go-task all -- --skip-tags pkg` to cover aggregate ordering across
+It executes `go-task all -- --skip-tags pkg,aur` to cover aggregate ordering across
 the user dotfiles, system, and browser policy layers without installing the
-full workstation package manifest on hosted runners.
+full workstation package manifest or AUR helper on hosted runners.
 
 GitHub Copilot review guidance lives in `.github/copilot-instructions.md`,
 with path-specific rules under `.github/instructions/`.

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -64,6 +64,7 @@ Review these host values before privileged use:
 - `inventory/host_vars/this_host/system.yml`
 - `inventory/host_vars/this_host/security.yml`
 - `inventory/host_vars/this_host/browser_policies.yml`
+- `roles/system/defaults/main.yml` AUR helper defaults
 
 The local host values are personal workstation choices. They are not a generic
 security baseline and should not be copied to servers, shared systems, or other

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,6 +29,8 @@ workstation settings, and browser policy overrides.
   default workflow.
 - System configuration prefers drop-ins and snippets where upstream supports
   them.
+- AUR helper bootstrap lives in the opt-in system layer, uses tag `aur`, and is
+  skipped in check mode, CI, and containers.
 - Cleanup and removal paths should stay explicit, narrow, and reviewable.
 - Check mode is available for privileged layers through `go-task system:check`
   and `go-task browser-policies:check`.

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -17,6 +17,7 @@ Review especially:
 - AI client telemetry and prompt logging settings
 - Sysctl tuning
 - Package installation in the opt-in system layer
+- AUR helper source, PKGBUILD, and build behavior in the opt-in system layer
 - npm, Yarn, pip, Terraform, K9s, and other user-level tool defaults
 
 Do not treat these values as universally secure. Adapt them to the host, threat

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,5 +3,5 @@ collections:
     version: "2.2.0"
     source: https://galaxy.ansible.com
   - name: community.general
-    version: "13.0.0"
+    version: "13.0.1"
     source: https://galaxy.ansible.com

--- a/roles/system/AGENTS.md
+++ b/roles/system/AGENTS.md
@@ -12,10 +12,11 @@ Keep the high-level flow predictable:
 
 - Assert supported OS.
 - Include distro-specific vars.
-- Derive CI, container, virtual machine, systemd, and timesyncd capability
+- Derive CI, container, virtual machine, systemd, timesyncd, and AUR capability
   guards.
 - Validate role variables.
 - Install `system_packages` with tag `pkg`.
+- Run AUR helper tasks with tag `aur` only when guarded as safe.
 - Run timezone tasks and guarded timesyncd tasks.
 - Run locale, console, login, limits, cron, sysctl, journald, and SSHD tasks.
 - Run Arch Linux tasks.
@@ -26,6 +27,8 @@ Keep the high-level flow predictable:
 ## Editing Rules
 
 - Preserve CI and container guards.
+- Keep AUR helper/package management tasks tagged `aur` and skipped in check
+  mode, CI, and containers.
 - Preserve `ansible_facts` based OS and virtualization checks.
 - Keep role input validation in `tasks/validate.yml`.
 - Preserve `become: true` where system paths or services require privilege.

--- a/roles/system/README.md
+++ b/roles/system/README.md
@@ -45,6 +45,7 @@ go-task test:system
 | Area | Notes |
 | ---- | ----- |
 | Packages | Installs `system_packages` from `vars/archlinux-packages.yml` when `system_packages_enabled` is true, including Neovim support tools such as `tree-sitter-cli`. |
+| AUR | Optionally bootstraps the configured AUR helper, `yay` by default, through tasks tagged `aur` in apply mode on non-CI, non-container hosts. |
 | Time | Configures `system_timezone`, which defaults to `UTC` and should be overridden in host vars. Manages `systemd-timesyncd` only when `system_timesyncd_enabled` is true, systemd is manageable, and the host is not a virtual machine. |
 | Journald | Writes `/etc/systemd/journald.conf.d/10-dotfiles.conf`. |
 | SSH daemon | Writes `/etc/ssh/sshd_config.d/20-dotfiles.conf` and validates effective sshd config. |
@@ -63,11 +64,13 @@ The role keeps privileged behavior explicit and guarded:
 
 1. Validate the supported OS.
 2. Load distro-specific vars and packages.
-3. Derive CI, container, virtual machine, systemd, user systemd, and timesyncd
-   capability guards.
+3. Derive CI, container, virtual machine, systemd, user systemd, timesyncd, and
+   AUR capability guards.
 4. Validate public role variables and host overrides.
 5. Install the package manifest under tag `pkg` when packages are enabled.
-6. Run time, locale, console, login, limits, cron, sysctl, journald, SSHD, OS,
+6. Bootstrap the AUR helper under tag `aur` when AUR is enabled, apply mode is
+   active, and the host is safe.
+7. Run time, locale, console, login, limits, cron, sysctl, journald, SSHD, OS,
    Docker, laptop, and user-service task files according to feature flags.
 
 ## Feature Flags
@@ -78,6 +81,7 @@ inside the system role:
 | Variable | Default | Controls |
 | -------- | ------- | -------- |
 | `system_packages_enabled` | `true` | Arch package manifest installation. |
+| `system_aur_enabled` | `true` | AUR helper bootstrap in apply mode on non-CI, non-container hosts. |
 | `system_timesyncd_enabled` | `true` | `systemd-timesyncd` drop-in management when the host is not a virtual machine. |
 | `system_sysctl_enabled` | `true` | Kernel parameter drop-in under `/etc/sysctl.d/`. |
 | `system_limits_enabled` | `true` | PAM limits drop-in under `/etc/security/limits.d/`. |
@@ -158,6 +162,7 @@ system_journald_settings:
 
 system_timezone: Europe/Warsaw
 system_packages_enabled: true
+system_aur_enabled: true
 system_timesyncd_enabled: true
 system_docker_enabled: false
 system_laptop_enabled: false
@@ -185,9 +190,16 @@ system_docker_overlay_options_enabled: true
 Do not rename upstream option keys inside these maps; only the Ansible variable
 names use lowercase snake_case.
 
+The default AUR helper bootstrap installs `yay` from
+`https://aur.archlinux.org/yay.git` into `/usr/bin/yay`. It installs Arch build
+dependencies from `system_aur_build_packages`, builds from
+`system_aur_build_root`, refuses root builds, and skips check mode, CI, and
+container execution. Use tag `aur` to select or skip this path.
+
 Common disable-only overrides:
 
 ```yaml
+system_aur_enabled: false
 system_sysctl_enabled: false
 system_limits_enabled: false
 system_docker_overlay_options_enabled: false
@@ -206,7 +218,7 @@ git diff --check
 
 `go-task test:system` first verifies the role's Arch package targets against a
 fresh pacman database, then runs the role twice in a fresh Arch Linux container
-with `--skip-tags pkg`; the second pass must be idempotent.
+with `--skip-tags pkg,aur`; the second pass must be idempotent.
 
 ## Rollback
 

--- a/roles/system/defaults/main.yml
+++ b/roles/system/defaults/main.yml
@@ -8,10 +8,18 @@ system_timezone: UTC
 system_motd_message: ""
 
 system_packages_enabled: true
+system_aur_enabled: true
 system_timesyncd_enabled: true
 system_docker_enabled: true
 system_laptop_enabled: true
 system_user_services_enabled: true
+
+system_aur_build_root: "{{ ansible_facts.user_dir }}/.cache/aur"
+system_aur_helper_package: yay
+system_aur_helper_repo: https://aur.archlinux.org/yay.git
+system_aur_helper_ref: master
+system_aur_helper_binary_path: /usr/bin/yay
+system_aur_helper_build_dir: "{{ system_aur_build_root }}/{{ system_aur_helper_package }}"
 
 system_ntp_service: systemd-timesyncd
 

--- a/roles/system/tasks/aur.yml
+++ b/roles/system/tasks/aur.yml
@@ -1,0 +1,82 @@
+---
+- name: AUR | Validate non-root builder
+  ansible.builtin.assert:
+    that:
+      - ansible_facts.user_id != system_root_user
+    fail_msg: "AUR packages must be built by a non-root user."
+    quiet: true
+  when:
+    - system_can_manage_aur | bool
+  tags:
+    - aur
+
+- name: AUR | Check yay package
+  ansible.builtin.command:
+    cmd: "pacman -Qq {{ system_aur_helper_package }}"
+  register: system_aur_helper_package_query
+  changed_when: false
+  failed_when: false
+  when:
+    - system_can_manage_aur | bool
+  tags:
+    - aur
+
+- name: AUR | Check yay binary
+  ansible.builtin.stat:
+    path: "{{ system_aur_helper_binary_path }}"
+  register: system_aur_helper_binary_stat
+  when:
+    - system_can_manage_aur | bool
+  tags:
+    - aur
+
+- name: AUR | Install build dependencies
+  become: true
+  ansible.builtin.package:
+    name: "{{ system_aur_build_packages }}"
+    state: present
+  when:
+    - system_can_manage_aur | bool
+    - (system_aur_helper_package_query.rc | default(1)) != 0
+    - not (system_aur_helper_binary_stat.stat.exists | default(false))
+  tags:
+    - aur
+
+- name: AUR | Ensure build root
+  ansible.builtin.file:
+    path: "{{ system_aur_build_root }}"
+    state: directory
+    mode: "0755"
+  when:
+    - system_can_manage_aur | bool
+    - (system_aur_helper_package_query.rc | default(1)) != 0
+    - not (system_aur_helper_binary_stat.stat.exists | default(false))
+  tags:
+    - aur
+
+- name: AUR | Clone yay repository
+  ansible.builtin.git:
+    repo: "{{ system_aur_helper_repo }}"
+    dest: "{{ system_aur_helper_build_dir }}"
+    version: "{{ system_aur_helper_ref }}"
+    update: true
+  when:
+    - system_can_manage_aur | bool
+    - (system_aur_helper_package_query.rc | default(1)) != 0
+    - not (system_aur_helper_binary_stat.stat.exists | default(false))
+  tags:
+    - aur
+
+- name: AUR | Build and install yay
+  ansible.builtin.command:
+    cmd: makepkg --syncdeps --install --noconfirm --needed
+    chdir: "{{ system_aur_helper_build_dir }}"
+    creates: "{{ system_aur_helper_binary_path }}"
+  environment:
+    PACMAN: sudo pacman
+  when:
+    - system_can_manage_aur | bool
+    - (system_aur_helper_package_query.rc | default(1)) != 0
+    - not (system_aur_helper_binary_stat.stat.exists | default(false))
+  tags:
+    - aur

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -76,6 +76,19 @@
   tags:
     - always
 
+- name: System | Set AUR guard
+  ansible.builtin.set_fact:
+    system_can_manage_aur: >-
+      {{
+        system_aur_enabled | bool
+        and not (ansible_check_mode | bool)
+        and not (system_is_container | bool)
+        and not (system_in_ci | bool)
+      }}
+  tags:
+    - always
+    - aur
+
 - name: System | Validate variables
   ansible.builtin.include_tasks:
     file: validate.yml
@@ -91,6 +104,14 @@
     - system_packages_enabled | bool
   tags:
     - pkg
+
+- name: System | Run AUR tasks
+  ansible.builtin.include_tasks:
+    file: aur.yml
+  when:
+    - system_aur_enabled | bool
+  tags:
+    - aur
 
 - name: System | Run time tasks
   ansible.builtin.include_tasks:

--- a/roles/system/tasks/validate.yml
+++ b/roles/system/tasks/validate.yml
@@ -10,10 +10,18 @@
       - system_timezone | length > 0
       - system_motd_message is string
       - system_packages_enabled is boolean
+      - system_aur_enabled is boolean
       - system_timesyncd_enabled is boolean
       - system_docker_enabled is boolean
       - system_laptop_enabled is boolean
       - system_user_services_enabled is boolean
+      - system_aur_build_packages is sequence
+      - system_aur_build_packages is not string
+      - not (system_aur_enabled | bool) or system_aur_build_packages | length > 0
+      - system_aur_helper_repo is string
+      - system_aur_helper_repo | length > 0
+      - system_aur_helper_ref is string
+      - system_aur_helper_ref | length > 0
       - system_ntp_service is string
       - not (system_timesyncd_enabled | bool) or system_ntp_service | length > 0
       - system_ntp_servers is sequence
@@ -98,6 +106,12 @@
       value: "{{ system_sysctl_file_path }}"
     - key: system_sshd_binary_path
       value: "{{ system_sshd_binary_path }}"
+    - key: system_aur_build_root
+      value: "{{ system_aur_build_root }}"
+    - key: system_aur_helper_binary_path
+      value: "{{ system_aur_helper_binary_path }}"
+    - key: system_aur_helper_build_dir
+      value: "{{ system_aur_helper_build_dir }}"
     - key: system_reflector_save_path
       value: "{{ system_reflector_save_path }}"
     - key: system_journald_dropin_dir
@@ -160,6 +174,8 @@
       value: "{{ system_docker_group }}"
     - key: system_docker_service_name
       value: "{{ system_docker_service_name }}"
+    - key: system_aur_helper_package
+      value: "{{ system_aur_helper_package }}"
     - key: system_reflector_package
       value: "{{ system_reflector_package }}"
     - key: system_reflector_timer_name

--- a/roles/system/vars/AGENTS.md
+++ b/roles/system/vars/AGENTS.md
@@ -12,6 +12,8 @@ Applies to `roles/system/vars/`.
   finalizing package changes.
 - Prefer official repository packages.
 - Do not add AUR-only packages unless AUR support is explicitly implemented.
+- Keep AUR helper build dependency variables separate from
+  `archlinux-packages.yml`, and ensure related tasks use tag `aur`.
 - Keep commented AUR notes as comments only.
 - Preserve existing package categories unless a regrouping is explicitly
   requested.

--- a/roles/system/vars/archlinux-packages.yml
+++ b/roles/system/vars/archlinux-packages.yml
@@ -104,6 +104,7 @@ system_packages:
   - irqbalance
   - tuned
   - eza
+  - linux-headers
   # : }}}
 
   # : utils {{{

--- a/roles/system/vars/archlinux-packages.yml
+++ b/roles/system/vars/archlinux-packages.yml
@@ -4,6 +4,15 @@
 system_packages:
   # : media {{{
   - feh
+  - obs-studio
+  - vlc
+  - vlc-cli
+  - ffmpeg
+  - xdg-desktop-portal
+  - xdg-desktop-portal-kde
+  - ffmpegthumbnailer
+  - v4l2loopback-dkms
+  - playerctl
   # : }}}
 
   # : monitoring {{{
@@ -101,6 +110,8 @@ system_packages:
   - keepassxc
   - nextcloud-client
   - rclone
+  - rsync
+  - less
   # : }}}
 
   # : dev {{{
@@ -109,7 +120,7 @@ system_packages:
   - python-pynvim
   - tree-sitter-cli
   - code
-  # - task
+  - go-task
   - tea
   - ast-grep
   - bat

--- a/roles/system/vars/archlinux.yml
+++ b/roles/system/vars/archlinux.yml
@@ -5,6 +5,9 @@ system_cron_service_name: cronie
 system_docker_group: docker
 system_docker_service_name: docker
 system_docker_conf_dir: /etc/docker
+system_aur_build_packages:
+  - base-devel
+  - git
 system_pacman_config_path: /etc/pacman.conf
 system_reflector_package: reflector
 system_reflector_config_path: /etc/xdg/reflector/reflector.conf


### PR DESCRIPTION
## Summary

- Add guarded system-role AUR helper bootstrap for `yay`, with validation for the new role inputs.
- Keep AUR execution out of check mode, CI, containers, and aggregate container tests through the `aur` tag.
- Refresh the Arch package manifest for workstation media, utility, and development tools.
- Update the Ansible collection pin for `community.general` from `13.0.0` to `13.0.1`; `ansible.posix` is already current at `2.2.0`.
- Document the opt-in AUR behavior, validation path, and operator review points.

## Release

This PR is intended to produce patch release `v2.2.3` after merge.

Release-As: 2.2.3

## Validation

- `uv run ansible-galaxy collection install -r requirements.yml`
- `git diff --check`
- `go-task lint`
- `go-task yamllint`
- `go-task actionlint`
- `go-task system:check`
- Branch diff text scan: no Cyrillic matches.

Not run locally:

- `go-task test:system`, `go-task verify`, and `go-task superlinter`; the local Docker daemon is unavailable.

## Safety

- Default `go-task` remains user-level and sudo-free.
- Privileged system behavior remains behind explicit opt-in system tasks.
- AUR bootstrap is skipped in check mode, CI, and containers.
- No secrets, runtime state, profiles, kubeconfigs, or local generated workspaces are included.

## Rollback

Revert this PR. Hosts that already installed `yay` can remove it manually with pacman if the AUR helper should no longer be present.