### PR TITLE
Fix/deps

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,7 +12,7 @@ vars:
   DEPS_OS_ARCHLINUX: "{{.PACMAN_INSTALL}} uv git"
   DEPS_OS_SYSTEM_ARCHLINUX: "{{.PACMAN_INSTALL}} uv git sudo"
   DEPS_VERIFY_ARCHLINUX: "{{.PACMAN_INSTALL}} actionlint nodejs npm pre-commit stylua"
-  SUPERLINTER_IMAGE_TAG: "v8.6.0"
+  SUPERLINTER_IMAGE_TAG: "v8.7.0"
   SUPERLINTER_DOCKER_RUN: >-
     docker run
     --rm

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,9 @@
   "semanticCommits": "enabled",
   "semanticCommitType": "deps",
   "semanticCommitScope": null,
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "ansible-galaxy": {
     "enabled": true
   },
@@ -19,9 +22,9 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Update the Super-Linter container image used by Taskfile.yml.",
+      "description": "Update the SUPERLINTER_IMAGE_TAG variable in Taskfile.yml.",
       "managerFilePatterns": ["/^Taskfile\\.yml$/"],
-      "matchStrings": ["ghcr\\.io/super-linter/super-linter:(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"],
+      "matchStrings": ["SUPERLINTER_IMAGE_TAG: \"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""],
       "depNameTemplate": "ghcr.io/super-linter/super-linter",
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 collections:
   - name: ansible.posix
-    version: "2.2.0"
+    version: "2.2.1"
     source: https://galaxy.ansible.com
   - name: community.general
     version: "13.1.0"


### PR DESCRIPTION
# Summary

- TBD

# Scope

- [ ] User-level dotfiles only
- [ ] Inventory or Ansible plumbing
- [ ] Opt-in system role
- [ ] Browser, Thunderbird, or VS Code policies
- [ ] Neovim config
- [ ] CI, release, or repository tooling
- [ ] Documentation or AI instructions

# Validation

- [ ] `git diff --check`
- [ ] `go-task lint`
- [ ] `uv run yamllint .`
- [ ] `go-task verify`
- [ ] `go-task`
- [ ] `go-task docs:nvim-keymaps:check`
- [ ] `go-task test:nvim`
- [ ] `go-task system:check`
- [ ] `go-task test:system` (covered by `go-task verify`)
- [ ] `go-task browser-policies:check`
- [ ] `go-task superlinter` (targeted check when full `go-task verify` was not run)
- [ ] Not applicable, reason:

# Safety

- [ ] Default `go-task` remains user-level and does not require sudo
- [ ] Privileged behavior remains opt-in
- [ ] No secrets, tokens, runtime state, caches, profiles, or generated
      workspaces are committed
- [ ] System config changes prefer drop-ins where supported
- [ ] PAM limits and kernel module options use `limits.d` and `modprobe.d`
      snippets
- [ ] Ansible variables follow role prefixes and settings-map casing rules
- [ ] Role input variables are validated where the role exposes a contract
- [ ] README and nearest `AGENTS.md` files are updated when commands,
      structure, validation, or behavior changes
- [ ] Generated manuals such as `docs/nvim-keymaps.md` are current when their
      source config changes
- [ ] Copilot and `.github/instructions/` rules are updated when review
      expectations change
- [ ] Versioned automation remains covered by Renovate or has an explicit
      manual update reason
- [ ] Rollback path is clear for system-wide changes

# Notes

- TBD
